### PR TITLE
Add executable artifacts with shared-scripts install scheme

### DIFF
--- a/hatch_rs/plugin.py
+++ b/hatch_rs/plugin.py
@@ -64,7 +64,7 @@ class HatchRustBuildHook(BuildHookInterface[HatchRustBuildConfig]):
             # Perform any cleanup actions
             build_plan.cleanup()
 
-        if not build_plan.copied_artifacts and not build_plan.shared_data:
+        if not build_plan.copied_artifacts and not build_plan.shared_data and not build_plan.shared_scripts:
             raise ValueError("No libraries or generated outputs were created by the build.")
 
         # force include libraries
@@ -100,7 +100,12 @@ class HatchRustBuildHook(BuildHookInterface[HatchRustBuildConfig]):
         shared_data = build_data.setdefault("shared_data", {})
         shared_data.update(build_plan.shared_data)
 
+        shared_scripts = build_data.setdefault("shared_scripts", {})
+        shared_scripts.update(build_plan.shared_scripts)
+
         for path in force_include:
             self._logger.warning(f"Force include: {path}")
         for source, destination in shared_data.items():
             self._logger.warning("Shared data: %s -> %s", source, destination)
+        for source, destination in shared_scripts.items():
+            self._logger.warning("Shared script: %s -> %s", source, destination)

--- a/hatch_rs/structs.py
+++ b/hatch_rs/structs.py
@@ -27,6 +27,7 @@ __all__ = (
     "ResolvedTarget",
     "RustArtifactConfig",
     "ValidationCommandConfig",
+    "executable_name",
     "python_extension_name",
     "resolve_target_triple",
     "shared_library_name",
@@ -37,7 +38,7 @@ BuildType = Literal["debug", "release"]
 CargoTargetKind = Literal["lib", "bin", "example", "test", "bench"]
 CbindgenMode = Literal["cli", "build-script"]
 CompilerToolchain = Literal["gcc", "clang", "msvc"]
-InstallScheme = Literal["package", "shared-data", "validate-only"]
+InstallScheme = Literal["package", "shared-data", "shared-scripts", "validate-only"]
 Language = Literal["c", "c++"]
 Binding = Literal["cpython", "pybind11", "nanobind", "generic"]
 Platform = Literal["linux", "darwin", "win32"]
@@ -198,6 +199,14 @@ def shared_library_name(library: str, *, platform: Optional[str] = None) -> str:
     if platform == "linux":
         return f"lib{library}.so"
     raise ValueError(f"Unsupported platform: {platform}")
+
+
+def executable_name(name: str, *, platform: Optional[str] = None) -> str:
+    """Render a platform-specific executable filename for a Cargo bin/example target."""
+    platform = _normalize_platform(platform or environ.get("HATCH_RUST_PLATFORM", sys_platform))
+    if platform == "win32":
+        return f"{name}.exe"
+    return name
 
 
 def python_extension_name(source_stem: str, *, abi3: bool = False, platform: Optional[str] = None) -> str:
@@ -412,6 +421,11 @@ class RustArtifactConfig(BaseModel):
     cargo_target_kind: Optional[CargoTargetKind] = Field(default=None, alias="cargo-target-kind", description="Cargo target selector kind.")
     cargo_target: Optional[str] = Field(default=None, alias="cargo-target", description="Cargo target selector name.")
     crate_type: str = Field(default="cdylib", alias="crate-type", description="Rust crate type to pass through to rustc.")
+    install_scheme: InstallScheme = Field(
+        default="package",
+        alias="install-scheme",
+        description="How to include the compiled artifact: package, shared-data, or shared-scripts (executables on PATH).",
+    )
     destination: Optional[str] = Field(default=None, description="Wheel-relative destination template for the copied artifact.")
     search_deps: bool = Field(default=False, alias="search-deps", description="Search target/<triple>/<profile>/deps even if a root artifact exists.")
     features: Optional[List[str]] = Field(default=None, description="Cargo features to enable for this artifact.")
@@ -637,6 +651,7 @@ class HatchRustBuildPlan(HatchRustBuildConfig):
     _artifact_plans: List[PlannedArtifact] = PrivateAttr(default_factory=list)
     _copied_artifacts: List[CopiedArtifact] = PrivateAttr(default_factory=list)
     _shared_data: dict[str, str] = PrivateAttr(default_factory=dict)
+    _shared_scripts: dict[str, str] = PrivateAttr(default_factory=dict)
     _artifact_manifest_records: list[dict[str, str]] = PrivateAttr(default_factory=list)
     _resolved_target: Optional[ResolvedTarget] = PrivateAttr(default=None)
     _target_dir: Optional[Path] = PrivateAttr(default=None)
@@ -658,6 +673,10 @@ class HatchRustBuildPlan(HatchRustBuildConfig):
     @property
     def shared_data(self) -> dict[str, str]:
         return dict(self._shared_data)
+
+    @property
+    def shared_scripts(self) -> dict[str, str]:
+        return dict(self._shared_scripts)
 
     @property
     def resolved_target(self) -> Optional[ResolvedTarget]:
@@ -687,11 +706,16 @@ class HatchRustBuildPlan(HatchRustBuildConfig):
     def _is_python_extension_artifact(self, artifact: RustArtifactConfig) -> bool:
         return artifact.destination is not None and "{python_extension_name}" in artifact.destination
 
+    def _is_executable_artifact(self, artifact: RustArtifactConfig) -> bool:
+        return artifact.cargo_target_kind in ("bin", "example")
+
     def _artifact_role(self, artifact: RustArtifactConfig) -> str:
         if self._is_generated_artifact(artifact):
             return "generated-output"
         if self._is_python_extension_artifact(artifact):
             return "python-extension"
+        if self._is_executable_artifact(artifact):
+            return "executable"
         return artifact.crate_type
 
     def _artifact_manifest(self, artifact: RustArtifactConfig) -> Optional[Path]:
@@ -794,7 +818,9 @@ class HatchRustBuildPlan(HatchRustBuildConfig):
         if self._is_python_extension_artifact(artifact) and "apple" in resolved_target.triple:
             rustc_args.extend(("-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"))
         rustc_args.extend(self._artifact_rustc_args(artifact))
-        if "--crate-type" not in rustc_args:
+        # Executables (bin/example) are not crate-type artifacts; injecting
+        # --crate-type would build them as a library instead of a binary.
+        if "--crate-type" not in rustc_args and not self._is_executable_artifact(artifact):
             rustc_args.extend(("--crate-type", artifact.crate_type))
         if rustc_args:
             build_command.append("--")
@@ -881,6 +907,7 @@ class HatchRustBuildPlan(HatchRustBuildConfig):
         self._artifact_plans = []
         self._copied_artifacts = []
         self._shared_data = {}
+        self._shared_scripts = {}
         self._artifact_manifest_records = []
         self._libraries = []
 
@@ -971,6 +998,7 @@ class HatchRustBuildPlan(HatchRustBuildConfig):
             "shared_library": shared_library,
             "import_library": import_library,
             "python_extension_name": python_extension,
+            "executable": source.name,
         }
         try:
             rendered = template.format(**values)
@@ -1222,6 +1250,75 @@ class HatchRustBuildPlan(HatchRustBuildConfig):
             copied_artifacts.append(import_library)
         return copied_artifacts
 
+    def _default_executable_destination(self, artifact: RustArtifactConfig) -> str:
+        # Executables placed on PATH (shared-scripts) or alongside data files
+        # use a bare filename; packaged executables land inside the module.
+        if artifact.install_scheme in ("shared-scripts", "shared-data"):
+            return "{executable}"
+        return f"{self.module}/{{executable}}"
+
+    def _copy_executable(self, planned_artifact: PlannedArtifact, *, build_root: Path) -> list[CopiedArtifact]:
+        artifact = planned_artifact.artifact
+        target_path = self._require_target_path(planned_artifact)
+        name = artifact.cargo_target or artifact.name
+        if not name:
+            raise ValueError(f"Artifact '{self._artifact_label(artifact)}' of kind '{artifact.cargo_target_kind}' must set cargo-target or name.")
+        executable = executable_name(name, platform=planned_artifact.resolved_target.platform)
+        source = self._find_exact_artifact(target_path, executable, search_deps=artifact.search_deps, artifact=artifact)
+        template = artifact.destination or self._default_executable_destination(artifact)
+        distribution_path = self._format_destination(template, planned_artifact=planned_artifact, source=source)
+        return self._place_artifact(
+            source,
+            distribution_path,
+            build_root=build_root,
+            planned_artifact=planned_artifact,
+            role="executable",
+            install_scheme=artifact.install_scheme,
+        )
+
+    def _place_artifact(
+        self,
+        source: Path,
+        distribution_path: Path,
+        *,
+        build_root: Path,
+        planned_artifact: PlannedArtifact,
+        role: str,
+        install_scheme: str,
+        is_library: bool = False,
+    ) -> list[CopiedArtifact]:
+        """Place a built artifact per its install scheme: into the package
+        (``package``), the wheel's shared data (``shared-data``), or the wheel's
+        scripts directory on ``PATH`` (``shared-scripts``)."""
+        if install_scheme == "package":
+            return [
+                self._copy_artifact(
+                    source,
+                    distribution_path,
+                    build_root=build_root,
+                    is_library=is_library,
+                    planned_artifact=planned_artifact,
+                    role=role,
+                    install_scheme="package",
+                )
+            ]
+        if install_scheme == "validate-only":
+            return []
+        if install_scheme == "shared-data":
+            self._shared_data[str(source)] = distribution_path.as_posix()
+        elif install_scheme == "shared-scripts":
+            self._shared_scripts[str(source)] = distribution_path.as_posix()
+        else:
+            raise ValueError(f"Unsupported install scheme for artifact '{self._artifact_label(planned_artifact.artifact)}': {install_scheme}")
+        self._record_packaged_artifact(
+            planned_artifact=planned_artifact,
+            source=source,
+            distribution_path=distribution_path.as_posix(),
+            install_scheme=install_scheme,
+            role=role,
+        )
+        return []
+
     def _artifact_outputs(self, artifact: RustArtifactConfig) -> list[GeneratedOutputConfig]:
         return list(artifact.outputs)
 
@@ -1272,6 +1369,15 @@ class HatchRustBuildPlan(HatchRustBuildConfig):
                     source=source,
                     distribution_path=distribution_path.as_posix(),
                     install_scheme="shared-data",
+                    role="generated-output",
+                )
+            elif output.install_scheme == "shared-scripts":
+                self._shared_scripts[str(source)] = distribution_path.as_posix()
+                self._record_packaged_artifact(
+                    planned_artifact=planned_artifact,
+                    source=source,
+                    distribution_path=distribution_path.as_posix(),
+                    install_scheme="shared-scripts",
                     role="generated-output",
                 )
             else:
@@ -1424,6 +1530,10 @@ class HatchRustBuildPlan(HatchRustBuildConfig):
             copied_artifacts.extend(self._copy_python_extension(planned_artifact, build_root=build_root))
             if artifact.outputs:
                 copied_artifacts.extend(self._process_generated_outputs(planned_artifact, build_root=build_root))
+        elif self._is_executable_artifact(artifact):
+            copied_artifacts.extend(self._copy_executable(planned_artifact, build_root=build_root))
+            if artifact.outputs:
+                copied_artifacts.extend(self._process_generated_outputs(planned_artifact, build_root=build_root))
         else:
             copied_artifacts.extend(self._copy_cdylib(planned_artifact, build_root=build_root))
             if artifact.outputs:
@@ -1436,6 +1546,7 @@ class HatchRustBuildPlan(HatchRustBuildConfig):
         build_root = Path.cwd().resolve()
         self._copied_artifacts = []
         self._shared_data = {}
+        self._shared_scripts = {}
         self._artifact_manifest_records = []
         self._libraries = []
 

--- a/hatch_rs/tests/test_structs.py
+++ b/hatch_rs/tests/test_structs.py
@@ -5,7 +5,7 @@ from pathlib import Path, PureWindowsPath
 
 import pytest
 
-from hatch_rs.structs import HatchRustBuildPlan, python_extension_name, resolve_target_triple, shared_library_name, wheel_tag
+from hatch_rs.structs import HatchRustBuildPlan, executable_name, python_extension_name, resolve_target_triple, shared_library_name, wheel_tag
 
 
 @pytest.mark.parametrize(
@@ -95,6 +95,19 @@ def test_shared_library_name(platform: str, expected: str):
 )
 def test_python_extension_name(source_stem: str, platform: str, abi3: bool, expected: str):
     assert python_extension_name(source_stem, abi3=abi3, platform=platform) == expected
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected"),
+    [
+        ("linux", "mycli"),
+        ("darwin", "mycli"),
+        ("win32", "mycli.exe"),
+        ("manylinux_2_28_x86_64", "mycli"),
+    ],
+)
+def test_executable_name(platform: str, expected: str):
+    assert executable_name("mycli", platform=platform) == expected
 
 
 def test_build_plan_generates_cargo_invocation(tmp_path):
@@ -291,6 +304,86 @@ def test_build_plan_uses_explicit_target_for_shared_library_name(tmp_path):
     copied = tmp_path / "project" / "lib" / "libproject_ffi.dylib"
     assert copied.read_bytes() == b"shared library"
     assert plan.libraries == ["project/lib/libproject_ffi.dylib"]
+
+
+def test_build_plan_copies_executable_to_shared_scripts(tmp_path):
+    plan = HatchRustBuildPlan(
+        module="project",
+        path=tmp_path,
+        target="x86_64-unknown-linux-gnu",
+        artifacts=[
+            {
+                "name": "project-cli",
+                "manifest": "rust/Cargo.toml",
+                "cargo-target-kind": "bin",
+                "cargo-target": "project",
+                "install-scheme": "shared-scripts",
+            }
+        ],
+    )
+    plan.generate()
+    planned_artifact = plan._artifact_plans[0]
+    source = tmp_path / "rust" / "target" / "x86_64-unknown-linux-gnu" / "release" / "project"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"#!/bin/sh\necho cli\n")
+
+    plan._copy_outputs(planned_artifact, build_root=tmp_path)
+
+    # The executable is staged on PATH via shared-scripts, not copied into the package.
+    assert plan.shared_scripts == {str(source): "project"}
+    assert plan.shared_data == {}
+    assert plan.copied_artifacts == []
+    assert not (tmp_path / "project" / "project").exists()
+
+
+def test_build_plan_executable_command_omits_crate_type(tmp_path):
+    plan = HatchRustBuildPlan(
+        module="project",
+        path=tmp_path,
+        target="x86_64-unknown-linux-gnu",
+        artifacts=[
+            {
+                "name": "project-cli",
+                "manifest": "rust/Cargo.toml",
+                "cargo-target-kind": "bin",
+                "cargo-target": "project",
+                "install-scheme": "shared-scripts",
+            }
+        ],
+    )
+    plan.generate()
+    args = plan.cargo_invocations[0].args
+    assert "--bin" in args
+    assert "project" in args
+    # A binary must not be forced to a cdylib crate type.
+    assert "--crate-type" not in args
+
+
+def test_build_plan_copies_executable_into_package(tmp_path):
+    plan = HatchRustBuildPlan(
+        module="project",
+        path=tmp_path,
+        target="x86_64-pc-windows-msvc",
+        artifacts=[
+            {
+                "name": "project-cli",
+                "manifest": "rust/Cargo.toml",
+                "cargo-target-kind": "bin",
+                "cargo-target": "project",
+            }
+        ],
+    )
+    plan.generate()
+    planned_artifact = plan._artifact_plans[0]
+    source = tmp_path / "rust" / "target" / "x86_64-pc-windows-msvc" / "release" / "project.exe"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"MZ executable")
+
+    plan._copy_outputs(planned_artifact, build_root=tmp_path)
+
+    copied = tmp_path / "project" / "project.exe"
+    assert copied.read_bytes() == b"MZ executable"
+    assert plan.shared_scripts == {}
 
 
 def test_build_plan_processes_generated_outputs(tmp_path):


### PR DESCRIPTION
Support shipping Rust binaries (bin/example targets) in wheels, in addition to the existing cdylib extension modules.

- New "shared-scripts" install scheme places an artifact in the wheel's .data/scripts/ directory so `pip install` puts it on PATH (the executable equivalent of shared-data).
- Executable artifacts (cargo-target-kind bin/example) are now copied: previously they fell through to the cdylib path and failed looking for a lib<name> shared library.
- Skip the implicit --crate-type cdylib rustc arg for executables, which would otherwise build a binary target as a library.
- Add an executable_name() helper and a {executable} destination token.
- Route both compiled and generated outputs through shared-scripts, and forward shared_scripts from the build plan to hatchling build_data.
